### PR TITLE
Use double precision for grid axis step

### DIFF
--- a/src/grid.c
+++ b/src/grid.c
@@ -317,8 +317,8 @@ _open_grid(const char* const path,
   int var_id[2];
   size_t start = 0;
   size_t count = 2;
-  float x[2];
-  float y[2];
+  double x[2];
+  double y[2];
   float undef1;
   float undef2;
 
@@ -374,14 +374,14 @@ _open_grid(const char* const path,
     return 1;
   }
 
-  rc = nc_get_vara_float(nc->id, x_id, &start, &count, &x[0]);
+  rc = nc_get_vara_double(nc->id, x_id, &start, &count, &x[0]);
   if (rc) {
     set_fes_extended_error(
       fes, FES_NETCDF_ERROR, "%s (%s): %s", nc_strerror(rc), nc->lon, path);
     return 1;
   }
 
-  rc = nc_get_vara_float(nc->id, y_id, &start, &count, &y[0]);
+  rc = nc_get_vara_double(nc->id, y_id, &start, &count, &y[0]);
   if (rc) {
     set_fes_extended_error(
       fes, FES_NETCDF_ERROR, "%s (%s): %s", nc_strerror(rc), nc->lat, path);


### PR DESCRIPTION
This version of tide prediction for FES can handle cartesian grid. The longitude and latitude axes are regular and so we use this property to :
1. Detect if a axis is circular for the longitudes :  lon_step * number_lons = 360.0 (with a 1e-9 tolerance)
2. For a given lon or lat, get the index on the axis :  nearest_int(  (lon - lon_min) / lon_step )

Using a grid with a non rational step has led us to problems in the circularity detection and in getting the nearest points. Our grid has the following step :
  step_as_double = 0.03333333333333333
  step_as_float = 0.033333335

We propose to use a double precision step for both latitudes and longitudes axes in order to detect the longitude circularity and have a better precision for getting indexes on the axes

