### PR TITLE
2 important(?) definition fixes. And some documentation bug fixes

### DIFF
--- a/docs/source/core/constituent.rst
+++ b/docs/source/core/constituent.rst
@@ -22,7 +22,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A2
+            Schureman: Table 2, Page 164, Ref. A2
 
 
     .. autoattribute:: kMf
@@ -37,7 +37,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A6
+            Schureman: Table 2, Page 164, Ref. A6
 
     .. autoattribute:: kMtm
 
@@ -51,7 +51,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A7
+            Schureman: Table 2, Page 164, Ref. A7
 
     .. autoattribute:: kMsqm
 
@@ -65,7 +65,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A12
+            Schureman: Table 2, Page 164, Ref. A12
 
     .. autoattribute:: k2Q1
 
@@ -79,7 +79,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A17
+            Schureman: Table 2, Page 164, Ref. A17
 
     .. autoattribute:: kSigma1
 
@@ -93,7 +93,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A20
+            Schureman: Table 2, Page 164, Ref. A20
 
     .. autoattribute:: kQ1
 
@@ -107,7 +107,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A15
+            Schureman: Table 2, Page 164, Ref. A15
 
     .. autoattribute:: kRho1
 
@@ -121,7 +121,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A18
+            Schureman: Table 2, Page 164, Ref. A18
 
     .. autoattribute:: kO1
 
@@ -135,7 +135,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A14
+            Schureman: Table 2, Page 164, Ref. A14
 
     .. autoattribute:: kMP1
 
@@ -149,7 +149,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A29
+            Schureman: Table 2, Page 164, Ref. A29
 
 
     .. autoattribute:: kM11
@@ -164,7 +164,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A23
+            Schureman: Table 2, Page 164, Ref. A23
 
     .. autoattribute:: kM12
 
@@ -178,7 +178,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A16
+            Schureman: Table 2, Page 164, Ref. A16
 
     .. autoattribute:: kM13
 
@@ -202,7 +202,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A27
+            Schureman: Table 2, Page 164, Ref. A27
 
     .. autoattribute:: kPi1
 
@@ -216,7 +216,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B15
+            Schureman: Table 2, Page 164, Ref. B15
 
     .. autoattribute:: kP1
 
@@ -230,7 +230,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B14
+            Schureman: Table 2, Page 164, Ref. B14
 
 
     .. autoattribute:: kS1
@@ -245,7 +245,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B71
+            Schureman: Table 2, Page 164, Ref. B71
 
     .. autoattribute:: kK1
 
@@ -259,7 +259,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. Note 2
+            Schureman: Table 2, Page 165, Ref. Note 2
 
     .. autoattribute:: kPsi1
 
@@ -273,7 +273,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. B24
+            Schureman: Table 2, Page 165, Ref. B24
 
     .. autoattribute:: kPhi1
 
@@ -287,7 +287,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. B31
+            Schureman: Table 2, Page 165, Ref. B31
 
 
     .. autoattribute:: kTheta1
@@ -302,7 +302,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A28
+            Schureman: Table 2, Page 164, Ref. A28
 
     .. autoattribute:: kJ1
 
@@ -316,7 +316,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A24
+            Schureman: Table 2, Page 164, Ref. A24
 
     .. autoattribute:: kOO1
 
@@ -330,7 +330,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A31
+            Schureman: Table 2, Page 164, Ref. A31
 
     .. autoattribute:: kMNS2
 
@@ -344,7 +344,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 167, Ref. MNS2
+            Schureman: Table 2, Page 167, Ref. MNS2
 
     .. autoattribute:: kEps2
 
@@ -368,7 +368,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A42
+            Schureman: Table 2, Page 165, Ref. A42
 
     .. autoattribute:: kMu2
 
@@ -382,7 +382,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A45
+            Schureman: Table 2, Page 165, Ref. A45
 
     .. autoattribute:: k2MS2
 
@@ -406,7 +406,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A40
+            Schureman: Table 2, Page 165, Ref. A40
 
     .. autoattribute:: kNu2
 
@@ -420,7 +420,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A43
+            Schureman: Table 2, Page 165, Ref. A43
 
     .. autoattribute:: kM2
 
@@ -434,7 +434,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A39
+            Schureman: Table 2, Page 165, Ref. A39
 
 
     .. autoattribute:: kMKS2
@@ -459,7 +459,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 165, Ref. A44
+            Schureman: Table 2, Page 165, Ref. A44
 
     .. autoattribute:: kL2
 
@@ -473,7 +473,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. Note 3
+            Schureman: Table 2, Page 166, Ref. Note 3
 
     .. autoattribute:: k2MN2
 
@@ -497,7 +497,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. B40
+            Schureman: Table 2, Page 166, Ref. B40
 
     .. autoattribute:: kS2
 
@@ -511,7 +511,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. B39
+            Schureman: Table 2, Page 166, Ref. B39
 
     .. autoattribute:: kR2
 
@@ -525,7 +525,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. B41
+            Schureman: Table 2, Page 166, Ref. B41
 
     .. autoattribute:: kK2
 
@@ -539,7 +539,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. Note 4
+            Schureman: Table 2, Page 166, Ref. Note 4
 
     .. autoattribute:: kMSN2
 
@@ -563,7 +563,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. A48
+            Schureman: Table 2, Page 166, Ref. A49
 
     .. autoattribute:: k2SM2
 
@@ -607,7 +607,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 166, Ref. A82
+            Schureman: Table 2, Page 166, Ref. A82
 
     .. autoattribute:: kMK3
 
@@ -825,7 +825,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B6
+            Schureman: Table 2, Page 164, Ref. B6
 
     .. autoattribute:: kSa
 
@@ -839,7 +839,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B64
+            Schureman: Table 2, Page 164, Ref. B64
 
     .. autoattribute:: kSa1
 
@@ -853,7 +853,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B2
+            Schureman: Table 2, Page 164, Ref. B2
 
     .. autoattribute:: kSta
 
@@ -867,7 +867,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. B7
+            Schureman: Table 2, Page 164, Ref. B7
 
     .. autoattribute:: kMm1
 
@@ -881,7 +881,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Table 2
+            Schureman: Table 2, Page 164, Table 2
 
     .. autoattribute:: kMf1
 
@@ -905,7 +905,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A5
+            Schureman: Table 2, Page 164, Ref. A5
 
         .. warning::
 
@@ -923,7 +923,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A1
+            Schureman: Table 2, Page 164, Ref. A1
 
     .. autoattribute:: kMm2
 
@@ -937,7 +937,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A64
+            Schureman: Table 2, Page 164, Ref. A64
 
     .. autoattribute:: kMf2
 
@@ -951,7 +951,7 @@
 
         .. note::
 
-            Shureman: Table 2, Page 164, Ref. A65
+            Schureman: Table 2, Page 164, Ref. A65
 
     .. property:: name
 

--- a/examples/ex_astronomic_constants.py
+++ b/examples/ex_astronomic_constants.py
@@ -155,7 +155,7 @@ print(const)
 #
 # .. math::
 #
-#       \{2/3 - sin^2(\omega)\}\{1 - 3/2 \times sin(i)\} = 0.5021
+#       \{2/3 - sin^2(\omega)\}\{1 - 3/2 \times sin^2(i)\} = 0.5021
 #
 # .. math::
 #
@@ -170,11 +170,11 @@ print(f'{a65:.4f}')
 #
 # .. math::
 #
-#       sin^2(\omega) \times \cos^4(\frac{1}{2}i) = 0.1528
+#       sin^2(\omega) \times \cos^4(\frac{1}{2}i) = 0.1578
 #
 # .. math::
 #
-#       f(Mf) = sin^2(I) / 0.1528
+#       f(Mf) = sin^2(I) / 0.1578
 a66 = math.sin(const.w)**2 * math.cos(0.5 * const.i)**4
 print(f'a66 = {a66:.4f}')
 
@@ -217,7 +217,7 @@ print(f'a68 = {a68:.4f}')
 # .. math::
 #
 #       sin(\omega) \times sin^2(\frac{1}{2}\omega)
-#       \times cos^4(\frac{1}{2}i) = 0.0164``
+#       \times cos^4(\frac{1}{2}i) = 0.0164
 #
 # .. math::
 #
@@ -237,7 +237,7 @@ print(f'a69 = {a69:.4f}')
 #
 # .. math::
 #
-#       f(M_2) = sin^4(\frac{1}{2}I) / 0.9154
+#       f(M_2) = cos^4(\frac{1}{2}I) / 0.9154
 a70 = math.cos(0.5 * const.w)**4 * math.cos(0.5 * const.i)**4
 print(f'a70 = {a70:.4f}')
 

--- a/include/fes/angle/astronomic.hpp
+++ b/include/fes/angle/astronomic.hpp
@@ -262,7 +262,7 @@ class Astronomic {
   /// @return @f$(19.0444 \times sin^4(I) + 2.7702 \times sin^2(I) \times
   /// cos(2\nu) + 0.0981)^\frac{1}{2}@f$
   FES_MATH_CONSTEXPR auto f_k2() const noexcept -> double {
-    // SCHUREMAN P.46 (234)
+    // SCHUREMAN P.46 (235)
     auto sin_i2 = detail::math::pow<2>(std::sin(i_));
     return sqrt(19.0444 * detail::math::pow<2>(sin_i2) +
                 2.7702 * sin_i2 * std::cos(2.0 * nu_) + 0.0981);
@@ -320,7 +320,7 @@ class Astronomic {
     return f_m23() * f_k2();
   }
 
-  /// @brief Gets the node factor for the githu
+  /// @brief Gets the node factor for formula 141.
   ///
   /// @return @f$(\sin(I) - 5/4 sin^3(I)) / 0.3192@f$
   FES_MATH_CONSTEXPR auto f_141() const noexcept -> double {

--- a/include/fes/wave.hpp
+++ b/include/fes/wave.hpp
@@ -1049,13 +1049,14 @@ class SN4 : public Wave {
 /// <tr><th>V</th><th>u</th><th>Factor-f</th></tr>
 /// <tr><td>@f$4T - 2s + 2h@f$</td>
 /// <td>@f$+2\xi - 2\nu@f$</td>
-/// <td>@f$f(M_2)@f$</td></tr>
+/// <td>@f$f(M_2)^2@f$</td></tr>
 /// </table>
+/// @note Shureman: %Table 2a, Page 167
 class MS4 : public Wave {
  public:
   constexpr MS4()
       : Wave(kMS4, kShortPeriod, false, 4, -2, 2, 0, 0, 0, 0, 2, -2, 0, 0,
-             &angle::Astronomic::f_m2) {}
+             &angle::Astronomic::f_m22) {}
 };
 
 /// @brief @f$MK_4 = M_2 + K_2@f$

--- a/include/fes/wave.hpp
+++ b/include/fes/wave.hpp
@@ -1063,13 +1063,14 @@ class MS4 : public Wave {
 /// <table>
 /// <tr><th>V</th><th>u</th><th>Factor-f</th></tr>
 /// <tr><td>@f$4T - 2s + 4h@f$</td>
-/// <td>@f$2\xi - 2\nu - 2\nu^{\prime}@f$</td>
+/// <td>@f$2\xi - 2\nu - 2\nu^{\prime\prime}@f$</td>
 /// <td>@f$f(MK_4)@f$</td></tr>
 /// </table>
+/// @note Shureman: %Table 2a, Page 167
 class MK4 : public Wave {
  public:
   constexpr MK4()
-      : Wave(kMK4, kShortPeriod, false, 4, -2, 4, 0, 0, 0, 0, 2, -2, -2, 0,
+      : Wave(kMK4, kShortPeriod, false, 4, -2, 4, 0, 0, 0, 0, 2, -2, 0, -2,
              &angle::Astronomic::f_m2_k2) {}
 };
 

--- a/include/fes/wave.hpp
+++ b/include/fes/wave.hpp
@@ -1050,14 +1050,15 @@ class SN4 : public Wave {
 /// <tr><th>V</th><th>u</th><th>Factor-f</th></tr>
 /// <tr><td>@f$4T - 2s + 2h@f$</td>
 /// <td>@f$+2\xi - 2\nu@f$</td>
-/// <td>@f$f(M_2)^2@f$</td></tr>
+/// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Schureman: %Table 2a, Page 167
+/// @note Schureman: %Table 2a, Page 167.
+/// @note correct nodal factor: Pugh (1987). Tides, surges and mean sea-level (Page 111, Table 4.4)
 class MS4 : public Wave {
  public:
   constexpr MS4()
       : Wave(kMS4, kShortPeriod, false, 4, -2, 2, 0, 0, 0, 0, 2, -2, 0, 0,
-             &angle::Astronomic::f_m22) {}
+             &angle::Astronomic::f_m2) {}
 };
 
 /// @brief @f$MK_4 = M_2 + K_2@f$

--- a/include/fes/wave.hpp
+++ b/include/fes/wave.hpp
@@ -899,7 +899,7 @@ class MSN2 : public Wave {
 /// <td>@f$-2\nu@f$</td>
 /// <td>@f$f(KJ_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A48
+/// @note Shureman: %Table 2, Page 165, Ref. A49
 class Eta2 : public Wave {
  public:
   constexpr Eta2()

--- a/include/fes/wave.hpp
+++ b/include/fes/wave.hpp
@@ -216,7 +216,7 @@ namespace wave {
 /// <tr><th>V</th><th>u</th><th>Factor-f</th></tr>
 /// <tr><td>@f$s - p@f$</td><td>@f$0@f$</td><td>@f$f(Mm)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A2
+/// @note Schureman: %Table 2, Page 164, Ref. A2
 class Mm : public Wave {
  public:
   constexpr Mm()
@@ -232,7 +232,7 @@ class Mm : public Wave {
 /// <td>@f$-2\xi@f$</td>
 /// <td>@f$f(Mf)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A6
+/// @note Schureman: %Table 2, Page 164, Ref. A6
 class Mf : public Wave {
  public:
   constexpr Mf()
@@ -248,7 +248,7 @@ class Mf : public Wave {
 /// <td>@f$-2\xi@f$</td>
 /// <td>@f$f(Mf)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A7
+/// @note Schureman: %Table 2, Page 164, Ref. A7
 class Mtm : public Wave {
  public:
   constexpr Mtm()
@@ -264,7 +264,7 @@ class Mtm : public Wave {
 /// <td>@f$-2\xi@f$</td>
 /// <td>@f$f(Mf)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A12
+/// @note Schureman: %Table 2, Page 164, Ref. A12
 class Msqm : public Wave {
  public:
   constexpr Msqm()
@@ -280,7 +280,7 @@ class Msqm : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. B6
+/// @note Schureman: %Table 2, Page 164, Ref. B6
 class Ssa : public Wave {
  public:
   constexpr Ssa()
@@ -296,7 +296,7 @@ class Ssa : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. B64
+/// @note Schureman: %Table 2, Page 164, Ref. B64
 class Sa : public Wave {
  public:
   constexpr Sa()
@@ -312,7 +312,7 @@ class Sa : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A17
+/// @note Schureman: %Table 2, Page 164, Ref. A17
 class _2Q1 : public Wave {
  public:
   constexpr _2Q1()
@@ -328,7 +328,7 @@ class _2Q1 : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A20
+/// @note Schureman: %Table 2, Page 164, Ref. A20
 class Sigma1 : public Wave {
  public:
   constexpr Sigma1()
@@ -344,7 +344,7 @@ class Sigma1 : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A15
+/// @note Schureman: %Table 2, Page 164, Ref. A15
 class Q1 : public Wave {
  public:
   constexpr Q1()
@@ -360,7 +360,7 @@ class Q1 : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A18
+/// @note Schureman: %Table 2, Page 164, Ref. A18
 class Rho1 : public Wave {
  public:
   constexpr Rho1()
@@ -376,7 +376,7 @@ class Rho1 : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A14
+/// @note Schureman: %Table 2, Page 164, Ref. A14
 class O1 : public Wave {
  public:
   constexpr O1()
@@ -392,7 +392,7 @@ class O1 : public Wave {
 /// <td>@f$-\nu@f$</td>
 /// <td>@f$f(J_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A29
+/// @note Schureman: %Table 2, Page 164, Ref. A29
 class MP1 : public Wave {
  public:
   constexpr MP1()
@@ -408,7 +408,7 @@ class MP1 : public Wave {
 /// <td>@f$+2\xi - \nu@f$</td>
 /// <td>@f$f(O_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A16
+/// @note Schureman: %Table 2, Page 164, Ref. A16
 class M12 : public Wave {
  public:
   constexpr M12()
@@ -448,7 +448,7 @@ class M13 : public Wave {
 /// <td>@f$-\nu@f$</td>
 /// <td>@f$f(J_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A23
+/// @note Schureman: %Table 2, Page 164, Ref. A23
 class M11 : public Wave {
  public:
   constexpr M11()
@@ -464,7 +464,7 @@ class M11 : public Wave {
 /// <td>@f$-\nu@f$</td>
 /// <td>@f$f(J_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A27
+/// @note Schureman: %Table 2, Page 164, Ref. A27
 class Chi1 : public Wave {
  public:
   constexpr Chi1()
@@ -480,7 +480,7 @@ class Chi1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. B15
+/// @note Schureman: %Table 2, Page 165, Ref. B15
 class Pi1 : public Wave {
  public:
   constexpr Pi1()
@@ -496,7 +496,7 @@ class Pi1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. B14
+/// @note Schureman: %Table 2, Page 165, Ref. B14
 class P1 : public Wave {
  public:
   constexpr P1()
@@ -512,7 +512,7 @@ class P1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. B71
+/// @note Schureman: %Table 2, Page 165, Ref. B71
 class S1 : public Wave {
  public:
   constexpr S1()
@@ -528,7 +528,7 @@ class S1 : public Wave {
 /// <td>@f$- \nu@f$</td>
 /// <td>@f$f(K_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. Note 2
+/// @note Schureman: %Table 2, Page 165, Ref. Note 2
 class K1 : public Wave {
  public:
   constexpr K1()
@@ -544,7 +544,7 @@ class K1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. B24
+/// @note Schureman: %Table 2, Page 165, Ref. B24
 class Psi1 : public Wave {
  public:
   constexpr Psi1()
@@ -560,7 +560,7 @@ class Psi1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. B31
+/// @note Schureman: %Table 2, Page 165, Ref. B31
 class Phi1 : public Wave {
  public:
   constexpr Phi1()
@@ -576,7 +576,7 @@ class Phi1 : public Wave {
 /// <td>@f$-\nu@f$</td>
 /// <td>@f$f(J_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A28
+/// @note Schureman: %Table 2, Page 164, Ref. A28
 class Theta1 : public Wave {
  public:
   constexpr Theta1()
@@ -592,7 +592,7 @@ class Theta1 : public Wave {
 /// <td>@f$-\nu@f$</td>
 /// <td>@f$f(J_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A24
+/// @note Schureman: %Table 2, Page 164, Ref. A24
 class J1 : public Wave {
  public:
   constexpr J1()
@@ -608,7 +608,7 @@ class J1 : public Wave {
 /// <td>@f$-2\xi - \nu@f$</td>
 /// <td>@f$f(OO_1)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A31
+/// @note Schureman: %Table 2, Page 164, Ref. A31
 class OO1 : public Wave {
  public:
   constexpr OO1()
@@ -624,7 +624,7 @@ class OO1 : public Wave {
 /// <td>@f$+4\xi - 4\nu@f$</td>
 /// <td>@f$f(M_2)^2@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 167, Ref. MNS2
+/// @note Schureman: %Table 2, Page 167, Ref. MNS2
 class MNS2 : public Wave {
  public:
   constexpr MNS2()
@@ -655,7 +655,7 @@ class Eps2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A42
+/// @note Schureman: %Table 2, Page 165, Ref. A42
 class _2N2 : public Wave {
  public:
   constexpr _2N2()
@@ -671,7 +671,7 @@ class _2N2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A45
+/// @note Schureman: %Table 2, Page 165, Ref. A45
 class Mu2 : public Wave {
  public:
   constexpr Mu2()
@@ -702,7 +702,7 @@ class _2MS2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A40
+/// @note Schureman: %Table 2, Page 165, Ref. A40
 class N2 : public Wave {
  public:
   constexpr N2()
@@ -718,7 +718,7 @@ class N2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A43
+/// @note Schureman: %Table 2, Page 165, Ref. A43
 class Nu2 : public Wave {
  public:
   constexpr Nu2()
@@ -734,7 +734,7 @@ class Nu2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A39
+/// @note Schureman: %Table 2, Page 165, Ref. A39
 class M2 : public Wave {
  public:
   constexpr M2()
@@ -765,7 +765,7 @@ class MKS2 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A44
+/// @note Schureman: %Table 2, Page 165, Ref. A44
 class Lambda2 : public Wave {
  public:
   constexpr Lambda2()
@@ -781,7 +781,7 @@ class Lambda2 : public Wave {
 /// <td>@f$+2\xi - 2\nu - R@f$</td>
 /// <td>@f$f(L_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. Note 3
+/// @note Schureman: %Table 2, Page 166, Ref. Note 3
 class L2 : public Wave {
  public:
   constexpr L2()
@@ -820,7 +820,7 @@ class _2MN2 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. B40
+/// @note Schureman: %Table 2, Page 166, Ref. B40
 class T2 : public Wave {
  public:
   constexpr T2()
@@ -836,7 +836,7 @@ class T2 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. B39
+/// @note Schureman: %Table 2, Page 166, Ref. B39
 class S2 : public Wave {
  public:
   constexpr S2()
@@ -852,7 +852,7 @@ class S2 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. B41
+/// @note Schureman: %Table 2, Page 166, Ref. B41
 class R2 : public Wave {
  public:
   constexpr R2()
@@ -868,7 +868,7 @@ class R2 : public Wave {
 /// <td>@f$-2\nu^{\prime \prime}@f$</td>
 /// <td>@f$f(K_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. Note 4
+/// @note Schureman: %Table 2, Page 166, Ref. Note 4
 class K2 : public Wave {
  public:
   constexpr K2()
@@ -899,7 +899,7 @@ class MSN2 : public Wave {
 /// <td>@f$-2\nu@f$</td>
 /// <td>@f$f(KJ_2)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 165, Ref. A49
+/// @note Schureman: %Table 2, Page 165, Ref. A49
 class Eta2 : public Wave {
  public:
   constexpr Eta2()
@@ -960,7 +960,7 @@ class _2MK3 : public Wave {
 /// <td>@f$+3\xi - 3\nu@f$</td>
 /// <td>@f$f(M_3)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 166, Ref. A82
+/// @note Schureman: %Table 2, Page 166, Ref. A82
 class M3 : public Wave {
  public:
   constexpr M3()
@@ -1021,6 +1021,7 @@ class MN4 : public Wave {
 /// <td>@f$+4\xi - 4\nu@f$</td>
 /// <td>@f$f(M_2)^2@f$</td></tr>
 /// </table>
+/// @note Schureman: %Table 2a, Page 167
 class M4 : public Wave {
  public:
   constexpr M4()
@@ -1051,7 +1052,7 @@ class SN4 : public Wave {
 /// <td>@f$+2\xi - 2\nu@f$</td>
 /// <td>@f$f(M_2)^2@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2a, Page 167
+/// @note Schureman: %Table 2a, Page 167
 class MS4 : public Wave {
  public:
   constexpr MS4()
@@ -1067,7 +1068,7 @@ class MS4 : public Wave {
 /// <td>@f$2\xi - 2\nu - 2\nu^{\prime\prime}@f$</td>
 /// <td>@f$f(MK_4)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2a, Page 167
+/// @note Schureman: %Table 2a, Page 167
 class MK4 : public Wave {
  public:
   constexpr MK4()
@@ -1280,7 +1281,7 @@ class MSf : public Wave {
 /// <td>@f$f(Mm)@f$</td></tr>
 /// </table>
 /// @warning Same frequency as MSf Non Linear wave : 2s -2h
-/// @note Shureman: %Table 2, Page 164, Ref. %A5
+/// @note Schureman: %Table 2, Page 164, Ref. %A5
 /// @note Second order long period equilibrium in atlas of FES2014c as MSf_LP
 class A5 : public Wave {
  public:
@@ -1297,7 +1298,7 @@ class A5 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. B2
+/// @note Schureman: %Table 2, Page 164, Ref. B2
 class Sa1 : public Wave {
  public:
   constexpr Sa1()
@@ -1313,7 +1314,7 @@ class Sa1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$1@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. B7
+/// @note Schureman: %Table 2, Page 164, Ref. B7
 class Sta : public Wave {
  public:
   constexpr Sta()
@@ -1329,7 +1330,7 @@ class Sta : public Wave {
 /// <td>@f$-\xi@f$</td>
 /// <td>@f$f(141)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A64
+/// @note Schureman: %Table 2, Page 164, Ref. A64
 class Mm2 : public Wave {
  public:
   constexpr Mm2()
@@ -1345,10 +1346,10 @@ class Mm2 : public Wave {
 /// <td>@f$-2\xi@f$</td>
 /// <td>@f$f(Mf)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A8
+/// @note Schureman: %Table 2, Page 164, Ref. A8
 class Mm1 : public Wave {
  public:
-  // Shureman: Ref. A8, Page 164, Table 2.
+  // Schureman: Ref. A8, Page 164, Table 2.
   constexpr Mm1()
       : Wave(kMm1, kLongPeriod, false, 0, 1, 0, 1, 0, 0, 2, -2, 0, 0, 0,
              &angle::Astronomic::f_mf) {}
@@ -1362,10 +1363,9 @@ class Mm1 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$f(Mm)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A3
+/// @note Schureman: %Table 2, Page 164, Ref. A3
 class Mf1 : public Wave {
  public:
-  // Shureman: Ref. A8, Page 164, Table 2.
   constexpr Mf1()
       : Wave(kMf1, kLongPeriod, false, 0, 2, 0, -2, 0, 0, 0, 0, 0, 0, 0,
              &angle::Astronomic::f_mm) {}
@@ -1379,7 +1379,7 @@ class Mf1 : public Wave {
 /// <td>@f$-\xi@f$</td>
 /// <td>@f$f(141)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A65
+/// @note Schureman: %Table 2, Page 164, Ref. A65
 class Mf2 : public Wave {
  public:
   constexpr Mf2()
@@ -1395,7 +1395,7 @@ class Mf2 : public Wave {
 /// <td>@f$0@f$</td>
 /// <td>@f$f(Mm)@f$</td></tr>
 /// </table>
-/// @note Shureman: %Table 2, Page 164, Ref. A1
+/// @note Schureman: %Table 2, Page 164, Ref. A1
 class M0 : public Wave {
  public:
   constexpr M0()

--- a/include/fes/wave/table.hpp
+++ b/include/fes/wave/table.hpp
@@ -245,10 +245,10 @@ class Table {
   ///     the phase of the constituent of index \f$(k\f$).
   ///
   ///   The a priori analysis spectrum includes the most important astronomical
-  ///   constituents in the Darwin development, completed by Shureman in 1958,
+  ///   constituents in the Darwin development, completed by Schureman in 1958,
   ///   and many non-linear waves. The definition of tidal constants and
   ///   astronomical arguments is taken from FES2014 tidal prediction software
-  ///   and a complete definition of waves is also available in Shureman (1958).
+  ///   and a complete definition of waves is also available in Schureman (1958).
   ///   This spectrum is the most commonly used for harmonic analysis due the
   ///   simplification given by the nodal correction concept (\f$(f\f$) and
   ///   \f$(u\f$) coefficients above) which allows dealing with slow motions of

--- a/src/python/pyfes/wave_table.py
+++ b/src/python/pyfes/wave_table.py
@@ -99,11 +99,11 @@ class WaveTable(core.WaveTable):
               the phase of the constituent of index :math:`k`.
 
         The a priori analysis spectrum includes the most important astronomical
-        constituents in the Darwin development, completed by Shureman in 1958,
+        constituents in the Darwin development, completed by Schureman in 1958,
         and many non-linear waves. Tidal constants and astronomical arguments
         are now derived from this software, incorporating legacy data from
         FES2014. A comprehensive definition of waves can also be found in
-        Shureman (1958). This spectrum is the most commonly used for harmonic
+        Schureman (1958). This spectrum is the most commonly used for harmonic
         analysis due to the simplification given by the nodal correction concept
         (:math:`f` and :math:`u` coefficients above) which allows dealing with
         slow motions of the lunar ascending node and reducing the number of


### PR DESCRIPTION
**updated**

1) Found one coding error:
* MK4 coefficient was specified as nu' instead of nu'' (see 1st screenshot- Schureman)

2) Source citation clarification:
* M4 nodal factor is f(M2) as Schureman is in error. The correct source is Pugh 87 (compare screenshots. 2nd screenshot: Pugh 87. The first screenshot is Schureman)
![image](https://github.com/user-attachments/assets/0074aee2-a095-4eec-a414-c78cd44329ba)
<img width="504" alt="Screenshot 2025-01-09 at 13 07 38" src="https://github.com/user-attachments/assets/e2b9b0e1-3bf7-473f-a2cd-f1b7f1aa8595" />

3) Also found a small number of typos in the documentation for variable values and spelling.
