### PR TITLE
Add missing #include <exception>

### DIFF
--- a/include/fes/detail/thread.hpp
+++ b/include/fes/detail/thread.hpp
@@ -5,6 +5,7 @@
 /// @file include/fes/detail/thread.hpp
 /// @brief Parallelization
 #pragma once
+#include <exception>
 #include <thread>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
`std::current_exception` is declared there.